### PR TITLE
Ignore SPDX parentheses and add crate name to the license error message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,8 +78,9 @@ pub fn gen_ebuild_data( manifest_path: Option<&Path>
                 } else {
                     // Add the unknown license name to be corrected manually
                     println!(
-                        "WARNING: unknown license \"{}\", please correct manually",
-                        &lic
+                        "WARNING: unknown license \"{}\" at package \"{}\", please correct manually",
+                        &lic,
+                        &pkg.name,
                     );
                     licenses.insert(lic.to_string());
                 }

--- a/src/license.rs
+++ b/src/license.rs
@@ -160,6 +160,9 @@ pub fn split_spdx_license(str: &str) -> Vec<&str> {
     str.split('/')
         .flat_map(|l| l.split(" OR "))
         .flat_map(|l| l.split(" AND "))
+        .flat_map(|l| l.split("("))
+        .flat_map(|l| l.split(")"))
+        .filter(|l| !l.is_empty())
         .map(str::trim)
         .collect()
 }


### PR DESCRIPTION
This fixes issue #27.