### PR TITLE
Update to rustsec-0.30.1 to support recent Cargo.lock versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ anyhow = "1.0.56"
 cargo-lock = "8.0.2"
 cargo_metadata = "0.15.0"
 itertools = "0.10.3"
-rustsec = "0.26.0"
+rustsec = "0.30.1"
 structopt = "0.3.26"
 time = "0.3.9"
 
@@ -44,5 +44,4 @@ version = "1.15.0"
 default-features = false
 
 [features]
-default = ["vendored-libgit2"]
-vendored-libgit2 = ["rustsec/vendored-libgit2"]
+default = []


### PR DESCRIPTION
Cargo.lock updated to v4 in current stable, so update rustsec to support it. See: https://github.com/rustsec/rustsec/blob/main/rustsec/CHANGELOG.md#0301-2025-01-18

Additionally, rustsec moved from git2 to gix, dropping the need to vendor the git2 install, so remove that feature.